### PR TITLE
Fix version catalog duplicate alias

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -61,4 +61,3 @@ vosk-android-published = { module = "ai.vosk:vosk-android", version.ref = "vosk-
 # السطر اللي بعد منطقة التعارض في ملفك (مثلاً):
 
 coil-compose = { module = "io.coil-kt:coil-compose", version.ref = "coil" }
-coil-compose = { module = "io.coil-kt:coil-compose", version.ref = "coil" }


### PR DESCRIPTION
## Summary
- remove the duplicate `coil-compose` alias entry from the Gradle version catalog so the build can parse the file again

## Testing
- ./gradlew test *(fails: SDK location not found in container Android SDK)*

------
https://chatgpt.com/codex/tasks/task_e_68d0e1a4e354832db739b58a98900283