### PR TITLE
Add Maven repositories for tess-two and Vosk dependencies

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -61,4 +61,3 @@ vosk-android-published = { module = "ai.vosk:vosk-android", version.ref = "vosk-
 # السطر اللي بعد منطقة التعارض في ملفك (مثلاً):
 
 coil-compose = { module = "io.coil-kt:coil-compose", version.ref = "coil" }
-coil-compose = { module = "io.coil-kt:coil-compose", version.ref = "coil" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -11,6 +11,16 @@ dependencyResolutionManagement {
     repositories {
         google()
         mavenCentral()
+        maven("https://s01.oss.sonatype.org/content/repositories/releases/") {
+            content {
+                includeGroup("com.googlecode.tesseract.android")
+            }
+        }
+        maven("https://alphacephei.com/maven") {
+            content {
+                includeGroup("ai.vosk")
+            }
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- add Sonatype releases and alphacephei Maven repositories so Gradle can resolve tess-two and vosk-android artifacts used by the modules

## Testing
- ./gradlew :app:assembleDebug *(fails: SDK location not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d0e1a4e354832db739b58a98900283