### PR TITLE
Fix tess-two and Vosk dependencies resolution

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -44,21 +44,6 @@ mlkit-text-recognition = { module = "com.google.mlkit:text-recognition", version
 mlkit-text-recognition-chinese = { module = "com.google.mlkit:text-recognition-chinese", version.ref = "mlkit-text-recognition-cjk" }
 mlkit-text-recognition-devanagari = { module = "com.google.mlkit:text-recognition-devanagari", version.ref = "mlkit-text-recognition-cjk" }
 mlkit-text-recognition-korean = { module = "com.google.mlkit:text-recognition-korean", version.ref = "mlkit-text-recognition-cjk" }
-# --- داخل [libraries] ---
-
-# ... سطورك السابقة تبقى كما هي ...
-
-# Tess-two / Vosk aliases (احتفظنا بالاسمين المنشورين + اسمي فرعك)
-
-tess-two = { module = "com.googlecode.tesseract.android:tess-two", version.ref = "tess-two" }
-
-tess-two-published = { module = "com.googlecode.tesseract.android:tess-two", version.ref = "tess-two" }
-
-vosk-android = { module = "ai.vosk:vosk-android", version.ref = "vosk-android" }
-
-vosk-android-published = { module = "ai.vosk:vosk-android", version.ref = "vosk-android" }
-
-# السطر اللي بعد منطقة التعارض في ملفك (مثلاً):
-
-coil-compose = { module = "io.coil-kt:coil-compose", version.ref = "coil" }
+tess-two = { module = "com.rmtheis:tess-two", version.ref = "tess-two" }
+vosk-android = { module = "com.alphacephei:vosk-android", version.ref = "vosk-android" }
 coil-compose = { module = "io.coil-kt:coil-compose", version.ref = "coil" }


### PR DESCRIPTION
## Summary
- update tess-two dependency alias to the com.rmtheis coordinate that is available on Maven Central
- point the Vosk dependency alias to the com.alphacephei coordinate available on Maven Central
- remove the extra Maven repositories now that both artifacts resolve from Maven Central

## Testing
- ./gradlew :app:assembleDebug *(fails: Android SDK location not configured in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d0e1a4e354832db739b58a98900283