### PR TITLE
Restore tess-two and Vosk dependencies

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -44,21 +44,6 @@ mlkit-text-recognition = { module = "com.google.mlkit:text-recognition", version
 mlkit-text-recognition-chinese = { module = "com.google.mlkit:text-recognition-chinese", version.ref = "mlkit-text-recognition-cjk" }
 mlkit-text-recognition-devanagari = { module = "com.google.mlkit:text-recognition-devanagari", version.ref = "mlkit-text-recognition-cjk" }
 mlkit-text-recognition-korean = { module = "com.google.mlkit:text-recognition-korean", version.ref = "mlkit-text-recognition-cjk" }
-# --- داخل [libraries] ---
-
-# ... سطورك السابقة تبقى كما هي ...
-
-# Tess-two / Vosk aliases (احتفظنا بالاسمين المنشورين + اسمي فرعك)
-
 tess-two = { module = "com.googlecode.tesseract.android:tess-two", version.ref = "tess-two" }
-
-tess-two-published = { module = "com.googlecode.tesseract.android:tess-two", version.ref = "tess-two" }
-
 vosk-android = { module = "ai.vosk:vosk-android", version.ref = "vosk-android" }
-
-vosk-android-published = { module = "ai.vosk:vosk-android", version.ref = "vosk-android" }
-
-# السطر اللي بعد منطقة التعارض في ملفك (مثلاً):
-
-coil-compose = { module = "io.coil-kt:coil-compose", version.ref = "coil" }
 coil-compose = { module = "io.coil-kt:coil-compose", version.ref = "coil" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -11,6 +11,18 @@ dependencyResolutionManagement {
     repositories {
         google()
         mavenCentral()
+        maven {
+            url = uri("https://jitpack.io")
+            content {
+                includeGroup("com.googlecode.tesseract.android")
+            }
+        }
+        maven {
+            url = uri("https://alphacephei.com/maven")
+            content {
+                includeGroup("ai.vosk")
+            }
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- restore the tess-two dependency alias to the com.googlecode.tesseract.android coordinate used by the screen module
- restore the Vosk dependency alias to the ai.vosk coordinate expected by the core-ml module
- add scoped JitPack and Alphacephei Maven repositories so Gradle can resolve both artifacts during builds
- configure the JitPack and Alphacephei repositories with explicit `maven { url = uri(...) }` blocks so their content filters compile correctly in Kotlin DSL

## Testing
- ./gradlew :app:checkDebugAarMetadata --info *(fails: SDK location not configured in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d0e1a4e354832db739b58a98900283